### PR TITLE
runtest cmd line args. Fixes #42

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ message ("Generating project ${PROJECT_NAME}")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/deps/cmake_modules/")
 
 set(VARNAM_LIBRARY_NAME "varnam")
+set(ARGTABLE_LIBRARY_NAME "argtable2")
 set(VARNAM_LIBRARY_NAME_STATIC "varnamstatic")
 set(DEPS_LIBRARY_NAME "deps")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,5 +34,5 @@ set(test_executable_name runtests)
 
 add_executable(${test_executable_name} test-runner.c ${TEST_FILES})
 
-target_link_libraries(${test_executable_name} ${VARNAM_LIBRARY_NAME} ${CHECK_LIBRARIES} m)
+target_link_libraries(${test_executable_name} ${VARNAM_LIBRARY_NAME} ${ARGTABLE_LIBRARY_NAME} ${CHECK_LIBRARIES} m)
 

--- a/tests/test-runner.c
+++ b/tests/test-runner.c
@@ -12,13 +12,50 @@
 #include <check.h>
 #include "testcases.h"
 #include <time.h>
+#include <argtable2.h>
+
+/*struct arg_file *suite;
+ struct arg_file *testcases;
+ struct arg_end *end;*/
 
 int main(int argc, char **argv)
 {
     Suite *suite, *util, *commandline;
     SRunner *runner;
-    int failed, exit_code;
+    int failed, exit_code, nerrors;
+    struct arg_file *suite_arg;
+    struct arg_lit *help;
+    struct arg_lit *fork;
+    struct arg_file *test_arg;
+    struct arg_end *end;
 
+    void *argtable[] = {
+        suite_arg = arg_filen(NULL, NULL, "<suite_names>", 0, 10, "The test suite to run"),
+        test_arg = arg_file0("t", NULL, "<test_name>", "A test in the suite to run"),
+        help = arg_lit0("h", "help", "Display help text"),
+        fork = arg_lit0("f", NULL, "Run in forked mode"),
+        end = arg_end(20)
+    };
+
+    /*test_arg->hdr.flag |= ARG_HASOPTVALUE;*/
+    nerrors = arg_parse(argc, argv, argtable);
+
+    if(help->count > 0)
+    {
+        printf("usage : \n");
+        arg_print_syntax(stdout, argtable, "\n");
+        printf("Glossary : \n");
+        arg_print_glossary(stdout, argtable, " %-25s %s\n");
+        exit(0);
+    }
+
+    if(nerrors > 0)
+    {       
+        arg_print_errors(stdout, end, "runtest");
+        exit(1);
+    }
+
+    
     /* Cleaning the output directory */
     exit_code = system ("ruby test_output_cleanup.rb");
     if (exit_code != 0) {
@@ -44,8 +81,39 @@ int main(int argc, char **argv)
     srunner_add_suite (runner, commandline);
     srunner_set_log (runner, "testrun.log");
     srunner_set_xml (runner, "testrun.xml");
-    srunner_set_fork_status (runner, CK_NOFORK);
-    srunner_run_all (runner, CK_NORMAL);
+
+    if(fork->count == 0)
+    {
+        printf("Running in no fork mode\n");
+        srunner_set_fork_status (runner, CK_NOFORK);
+    }
+    else
+        printf("Running in forked mode\n");
+    
+
+    if(suite_arg->count == 0)
+        srunner_run_all (runner, CK_NORMAL);
+    else
+    {
+        int i;
+
+        if(test_arg->count > 0 && suite_arg->count > 1)
+        {
+            printf("Only one suite and one test can be specified if a test argument is provided\nSee --help for more\n");
+            exit(1);
+        }
+        else if(test_arg->count > 0)
+            srunner_run (runner, suite_arg->filename[0], test_arg->filename[0], CK_NOFORK);
+        else
+        {
+            /*If only suite names are specified*/
+            for(i=0; i<suite_arg->count; i++)
+            {
+                srunner_run (runner, suite_arg->filename[i], NULL, CK_NOFORK);
+            }
+        }
+    }
+
     failed = srunner_ntests_failed (runner);
     srunner_free (runner);
 


### PR DESCRIPTION
runtest can now parse command line arguments using argtable2. It is possible to run specific test suites (eg : util + commandline) or a specific test in a specific suite (eg: "initialization" in the suite "core"). The  -f parameter causes the tests to run in forked mode and --help displays the help text.

argtable2 is available in debian (I use linux mint) repository (libargtable2) so I hope that won't be a problem.

However, I could not figure out a way to run specific tests from specific suites. For example, I cannot run selectively the tests "initialization" and "varnamc" from the suites "core" and "commandline" together (I can run all the tests in both core and util together though). argtable won't let me set both suite name and test name as parameters that can take variable number of arguments. 
