### PR TITLE
Make the symbols dir finding function accessible

### DIFF
--- a/api.h
+++ b/api.h
@@ -26,6 +26,9 @@ varnam_set_symbols_dir (const char *dir);
 VARNAM_EXPORT strbuf*
 varnam_get_symbols_dir ();
 
+VARNAM_EXPORT extern const char*
+varnam_find_symbols_file_directory ();
+
 /**
  * Sets the suggestions directory where all the learning data will be stored. This value will be used
  * when initializing using varnam_init_from_id

--- a/varnam.c
+++ b/varnam.c
@@ -215,7 +215,7 @@ static const char* symbolsFileSearchPath[] = {
 };
 
 const char*
-find_symbols_file_directory()
+varnam_find_symbols_file_directory()
 {
   int i;
 
@@ -235,7 +235,7 @@ static strbuf*
 find_symbols_file_path (const char *langCode)
 {
   strbuf *path;
-	const char* dir = find_symbols_file_directory();
+	const char* dir = varnam_find_symbols_file_directory();
 	if (dir == NULL) {
 		return NULL;
 	}
@@ -522,7 +522,7 @@ varnam_get_all_handles()
 	int rc;
 	char *msg;
 
-	const char* symbolsFileDir = find_symbols_file_directory();
+	const char* symbolsFileDir = varnam_find_symbols_file_directory();
 	if (symbolsFileDir == NULL)
 		return NULL;
 


### PR DESCRIPTION
Currently, there's no way to know where the symbols/scheme files are located. There's `varnam_get_symbols_dir()`, but that only works if the directory is set with `varnam_set_symbols_dir()`. This change allows external programs using libvarnam to find the correct location where libvarnam is storing the symbol files.